### PR TITLE
Array creation and primitive type class literals are parsable

### DIFF
--- a/docs/manual/advanced-features.tex
+++ b/docs/manual/advanced-features.tex
@@ -1203,8 +1203,11 @@ The set of permitted expressions is a subset of all Java expressions:
 \item
   an array access.  For example:  \<this.myArray[i]>, \<vals[\#1]>.
 
+\item
+  an array creation. For example: \<new int[10]>, \<new String[] {"a", "b"}>.
+
 \item literals: string, integer, char, long, float, double, null literals.
-  Class literals with class or interface type.
+  Class literals with class, interface, primitive or void type.
 
 \item a method invocation on any expression.
   This even works for overloaded methods and methods with type parameters.
@@ -1247,7 +1250,7 @@ The following Java expressions may not currently be written:
 % The Checker Framework is best at reasoning about Java expressions that
 % are variable references, but these expressions are not.
 \begin{itemize}
-\item Class literals with primitive type (int.class) or with array type (String[].class).
+\item Class literals with with array type (String[].class).
 \item String concatenation expressions.
 \item Mathematical operators (plus, minus, division, ...).
 \item Comparisons (equality, less than, etc.).

--- a/framework/tests/flowexpression/ArrayCreationParsing.java
+++ b/framework/tests/flowexpression/ArrayCreationParsing.java
@@ -1,0 +1,19 @@
+package flowexpression;
+
+import testlib.flowexpression.qual.FlowExp;
+
+public class ArrayCreationParsing {
+    @FlowExp("new int[2]") Object value1;
+
+    @FlowExp("new int[2][2]") Object value2;
+
+    @FlowExp("new String[2]") Object value3;
+
+    @FlowExp("new String[] {\"a\", \"b\"}") Object value4;
+
+    void method(@FlowExp("new java.lang.String[2]") Object param) {
+        value3 = param;
+        // :: error: (assignment.type.incompatible)
+        value1 = param;
+    }
+}

--- a/framework/tests/flowexpression/ClassLiterals.java
+++ b/framework/tests/flowexpression/ClassLiterals.java
@@ -20,15 +20,16 @@ public class ClassLiterals {
         @FlowExp("java.lang.String.class") Object l6 = p3;
     }
 
-    // :: error: (expression.unparsable.type.invalid)
-    @FlowExp("int.class") String s0;
+    @FlowExp("void.class") String s0;
+
+    @FlowExp("int.class") String s1;
 
     // :: error: (expression.unparsable.type.invalid)
-    @FlowExp("int[].class") String s1;
+    @FlowExp("int[].class") String s2;
 
     // :: error: (expression.unparsable.type.invalid)
-    @FlowExp("String[].class") String s2;
+    @FlowExp("String[].class") String s3;
 
     // :: error: (expression.unparsable.type.invalid)
-    @FlowExp("java.lang.String[].class") String s3;
+    @FlowExp("java.lang.String[].class") String s4;
 }


### PR DESCRIPTION
New parsable types:

1. Array creation expressions (`new int[2]`, `new String[] {"a", "b"}`, `new java.lang.String[2]`;
2. Class literals with primitive or void type (`int.class`, `double.class`, `void.class`).
